### PR TITLE
Update .gitignore to include 7s model and model loading path in main.py

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
-server/umsi-3s.h5
+server/models/umsi-3s.h5
+server/models/umsi-7s.h5

--- a/server/main.py
+++ b/server/main.py
@@ -22,7 +22,7 @@ import cv2
 
 
 # Load the model when the script is initialized
-weightsPath = 'umsi-3s.h5'
+weightsPath = 'models/umsi-3s.h5'
 model = tf.keras.models.load_model(weightsPath)
 
 def padding(img, shape_r, shape_c, channels=3):


### PR DESCRIPTION
Correct the path for model files in .gitignore and update the model loading path in main.py to reflect the new directory structure. This change ensures that the model files are correctly ignored by version control and loaded at runtime.